### PR TITLE
Indicate unused event parameters

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -35,13 +35,13 @@ client.on("messageCreate", async msg => {
       break;
   }
 });
-client.on("messageReactionAdd", (msg, emoji, userID) => {
+client.on("messageReactionAdd", (msg, _emoji, userID) => {
   if(msg.id !== "739544190689476688")
     return;
 
   msg.channel.guild.addMemberRole(userID, "739326324702707723");
 });
-client.on("messageReactionRemove", (msg, emoji, userID) => {
+client.on("messageReactionRemove", (msg, _emoji, userID) => {
   if(msg.id !== "739544190689476688")
     return;
 


### PR DESCRIPTION
Some event paramters did not have an underscore preceding the parameter name when said parameters were not used anywhere in the events themselves.